### PR TITLE
Toward #6: improve error message for missing extensions.

### DIFF
--- a/ang/crmExt/OverlayCtrl.html
+++ b/ang/crmExt/OverlayCtrl.html
@@ -47,7 +47,7 @@
         <td class="label">{{ts('Local path')}}</td>
         <td>
           <div class="crm-inline-error crm-error" ng-if="(model.status == 'installed-missing')">
-            {{ts('The extension file cannot be loaded from the following path. Please restore the file or disable the extension.')}}
+            {{ts('The extension file cannot be loaded from its path. Please restore the file or disable the extension.')}}
           </div>
           <span ng-if="(model.path.length)">{{model.path}}</span>
           <div class="crm-inline-error crm-error" ng-if="(model.status == 'disabled-missing')">


### PR DESCRIPTION
Regarding https://github.com/twomice/org.civicrm.extensionsui/issues/6#issuecomment-287804332: "_The error message says the extension cannot be loaded from the following path but does not actually give the path._"

This uses a kind of compromise language for missing extensions that should work acceptably whether the file path displays for not.