### PR TITLE
Fixed bug where all remote extensions were displayed as upgradable.

### DIFF
--- a/ang/crmExt/services/extension.service.js
+++ b/ang/crmExt/services/extension.service.js
@@ -143,7 +143,7 @@
       var localVersion = _.result(this.local, 'version');
       var remoteVersion = _.result(this.remote, 'version');
       var hasUpgrade = version_compare (localVersion, remoteVersion, '<');
-      return (hasUpgrade ? remoteVersion : false);
+      return (hasUpgrade && localVersion !== null ? remoteVersion : false);
     };
 
     /**


### PR DESCRIPTION
This change does the trick.

It does result in following edge case, where I have an old version of CiviDiscount downloaded and a newer version is available. I think displaying the option to upgrade a disabled/uninstalled extension is a choice, not a bug. Argument for doing it this way:

> Joe was very excited to try CiviDiscount 3.4, but he found a bug which presented so much of a
> problem for him that he decided to disable it. Oh, hey, 3.7 is out -- maybe his bug report has been
> addressed!

![image](https://user-images.githubusercontent.com/871819/52447999-784fc980-2b00-11e9-990c-9c55125f6b87.png)
